### PR TITLE
update API for partial course search term

### DIFF
--- a/src/main/java/base/course/Course.java
+++ b/src/main/java/base/course/Course.java
@@ -30,7 +30,7 @@ public class Course implements Serializable {
 	private Department department;
 
 	public Course() {
-		
+
 	}
 
 	public Course(int number, String title, Department department) {
@@ -92,6 +92,10 @@ public class Course implements Serializable {
 
 	public void setDepartment(Department department) {
 		this.department = department;
+	}
+
+	public String toString() {
+	  return getDepartment().getPrefix() + " " + getNumber() + " " + getTitle();
 	}
 }
 

--- a/src/main/java/base/course/CourseController.java
+++ b/src/main/java/base/course/CourseController.java
@@ -19,13 +19,13 @@ public class CourseController {
 	private DepartmentService departmentService;
 
 	@RequestMapping("courses")
-	public List<Course> getAllCourses(@RequestParam(value="dept", required = false) String dept) {
-		if (!StringUtils.isEmpty(dept)) {
-			Department department = departmentService.getDepartmentByName(dept.toUpperCase());
-			return department != null ? department.getCourses() : Collections.emptyList();
+	public List<Course> getAllCourses(@RequestParam(value="term", required = false) String term) {
+		if (!StringUtils.isEmpty(term)) {
+			return courseService.getCoursesBySearchTerm(term);
 		}
-
-		return courseService.getAllCourses();
+    else {
+      return courseService.getAllCourses();
+    }
 	}
 
 	@RequestMapping("courses/{id}")

--- a/src/main/java/base/course/CourseService.java
+++ b/src/main/java/base/course/CourseService.java
@@ -4,10 +4,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 import java.util.List;
+import java.util.stream.StreamSupport;
+
 @Service
 public class CourseService {
-	
+
 	@Autowired
 	private CourseRepository courseRepository;
 
@@ -16,7 +19,13 @@ public class CourseService {
 		courseRepository.findAll().forEach(courses::add);
 		return courses;
 	}
-	
+
+	public List<Course> getCoursesBySearchTerm(String term) {
+	  return StreamSupport.stream(courseRepository.findAll().spliterator(), true)
+      .filter(c -> c.toString().toLowerCase().contains(term.toLowerCase()))
+      .collect(Collectors.toList());
+  }
+
 	public Course getCourse(Long id) {
 		return courseRepository.findOne(id);
 	}
@@ -25,12 +34,12 @@ public class CourseService {
 	{
 		return courseRepository.findCourseByTitle(title);
 	}
-	
+
 	public void addCourse(Course course)
 	{
 		courseRepository.save(course);
 	}
-	
+
 	public void updateCourse(Long id, Course course)
 	{
 		Course temp = courseRepository.findOne(id);
@@ -46,7 +55,7 @@ public class CourseService {
 			courseRepository.save(temp);
 		}
 	}
-	
+
 	public void deleteCourse(Long id)
 	{
 		courseRepository.delete(id);


### PR DESCRIPTION
Updates the API to accept a search term to match on. This matches on a String representation of the Course that includes the department abbreviation, course number, and course title. This change was necessary for #152 so that the front-end received an already filtered list of Courses instead of returning all courses over the API and then filtering in the front end. 